### PR TITLE
Invoke ruff with "check" command.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ strict = true
 [tool.poe.tasks]
 _format = [ { shell = "isort . && black ." } ]
 _check = [ { shell = "isort --check . && black --check ." } ]
-_lint = [ { shell = "ruff . && mypy ." } ]
+_lint = [ { shell = "ruff check . && mypy ." } ]
 _test = [ { shell = "pytest" } ]
 format = [ "_format", "_lint" ]
 check = [ "_check", "_lint", "_test" ]


### PR DESCRIPTION
`ruff <directory>` is deprecated:

```shell
$ poetry run poe format
Poe => isort . && black .
Skipped 4 files
All done! ✨ 🍰 ✨
2 files left unchanged.
Poe => ruff . && mypy .
warning: `ruff <path>` is deprecated. Use `ruff check <path>` instead.
```